### PR TITLE
rgw rate limits: limits for object delete, bucket create & delete ops

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,18 @@
+ceph (0.94.2-1~bpo70+1.fk7) stable; urgency=low
+
+  * Flipkart upstream release
+    - per-account accept & reject GET / PUT call 'perf' counters
+
+ -- FK D42 team <d42-maintainers@flipkart.com>  Tue, 20 Sep 2016 21:58:05 +0530
+
+ceph (0.94.2-1~bpo70+1.fk6) stable; urgency=low
+
+  * Flipkart upstream release
+    - rate limits for 'anonymous' GET / PUT calls
+    - 'perf' counters for calls rejected due to rate limits
+
+ -- FK D42 team <d42-maintainers@flipkart.com>  Mon, 19 Sep 2016 15:20:37 +0530
+
 ceph (0.94.2-1~bpo70+1.fk5) stable; urgency=low
 
   * Flipkart incremental upstream release

--- a/src/rgw/rgw_rate_limit.cc
+++ b/src/rgw/rgw_rate_limit.cc
@@ -37,8 +37,14 @@ typedef unordered_map<string, api_counter_t *> RGW_api_ctr_t;
 typedef RGW_api_ctr_t::iterator api_ctr_it;
 typedef RGW_api_ctr_t::const_iterator api_ctr_cit;
 
+#define DEFAULT_LIMIT_USER "default.user"
+api_counter_t default_obj_get, default_obj_put, default_obj_del;
+api_counter_t default_bucket_create, default_bucket_delete;
+Mutex *default_limit_lock;
+
 // Maps of user counters
-RGW_api_ctr_t *rgw_get_ctrs, *rgw_put_ctrs;
+RGW_api_ctr_t *obj_get_ctr_map, *obj_put_ctr_map, *obj_del_ctr_map;
+RGW_api_ctr_t *bucket_create_ctrs, *bucket_delete_ctrs;
 
 
 // Helpers
@@ -69,6 +75,17 @@ static string get_period_str(const Period period)
   return retval;
 }
 
+static void init_api_limit(api_counter_t *ctr,
+			   const unsigned long long limit,
+			   const Period period)
+{
+  ctr->recvd.set(0);
+  ctr->limit.set(limit);
+  ctr->period = period;
+  ctr->accept_idx = -1;
+  ctr->reject_idx = -1;
+}
+
 static void dump_limit_config(RGW_api_ctr_t *ctrs)
 {
   for (api_ctr_cit iter = ctrs->begin(); iter != ctrs->end(); ++iter) {
@@ -93,10 +110,35 @@ static void dump_ctr_stats(RGW_api_ctr_t *ctrs)
 
 static void rgw_api_ctr_dump(int signum)
 {
-  dout(0) << "*** GET stats dump" << dendl;
-  dump_ctr_stats(rgw_get_ctrs);
-  dout(0) << "*** PUT stats dump" << dendl;
-  dump_ctr_stats(rgw_put_ctrs);
+  dout(0) << "*** Object GET stats dump" << dendl;
+  dump_ctr_stats(obj_get_ctr_map);
+  dout(0) << "*** Object PUT stats dump" << dendl;
+  dump_ctr_stats(obj_put_ctr_map);
+  dout(0) << "*** Object DELETE stats dump" << dendl;
+  dump_ctr_stats(obj_del_ctr_map);
+  dout(0) << "*** Bucket CREATE stats dump" << dendl;
+  dump_ctr_stats(bucket_create_ctrs);
+  dout(0) << "*** Bucket DELETE stats dump" << dendl;
+  dump_ctr_stats(bucket_delete_ctrs);
+}
+
+static void update_one_default_limit(api_counter_t *default_ctr, RGW_api_ctr_t *ctrs)
+{
+  api_ctr_cit iter;
+  if ( (iter = ctrs->find(DEFAULT_LIMIT_USER)) != ctrs->end() ) {
+    api_counter_t *ctr = iter->second;
+    default_ctr->limit.set(ctr->limit.read());
+    default_ctr->period = ctr->period;
+  }
+}
+
+static void update_default_limits()
+{
+  update_one_default_limit(&default_obj_get, obj_get_ctr_map);
+  update_one_default_limit(&default_obj_put, obj_put_ctr_map);
+  update_one_default_limit(&default_obj_del, obj_del_ctr_map);
+  update_one_default_limit(&default_bucket_create, bucket_create_ctrs);
+  update_one_default_limit(&default_bucket_delete, bucket_delete_ctrs);
 }
 
 static api_counter_t *parse_limit(const YAML::Node& limit_data)
@@ -125,14 +167,8 @@ static api_counter_t *parse_limit(const YAML::Node& limit_data)
   return api_ctr;
 }
 
-static void swap_ctr(api_counter_t *old_ctr, api_counter_t *new_ctr)
-{
-  old_ctr->limit.set(new_ctr->limit.read());
-  old_ctr->period = new_ctr->period;
-}
-
 // Parse config file into tmp map & swap with current map
-static int load_limit_config_file(bool init)
+static int load_limit_config_file()
 {
   YAML::Node doc;
   try {
@@ -147,9 +183,12 @@ static int load_limit_config_file(bool init)
   dout(0) << "*** Rate limit config parsing ***" << dendl;
 
   for ( unsigned int i=0; i < doc.size(); i++ ) {
-    string user;
     const YAML::Node& node = doc[i];
+    if ( !node.size() ) {
+      continue;
+    }
 
+    string user;
     try {
       node["user"] >> user;
     } catch (...) {
@@ -157,64 +196,53 @@ static int load_limit_config_file(bool init)
       continue;
     }
 
-    api_counter_t *get_ctr;
+    api_counter_t *obj_get_ctr, *obj_put_ctr, *obj_del_ctr;
+    api_counter_t *create_ctr, *del_ctr;
+    obj_get_ctr = obj_put_ctr = obj_del_ctr = NULL;
+    create_ctr = del_ctr = NULL;
     try {
-      const YAML::Node& get = node["get"];
-      if ( (get_ctr = parse_limit(get)) == NULL ) {
-	throw;
-      } else {
-	if ( init ) {
-	  (*rgw_get_ctrs)[user] = get_ctr;
-	} else {
-	  api_ctr_it iter = rgw_get_ctrs->find(user);
-	  if ( iter != rgw_get_ctrs->end() ) {
-	    api_counter_t *ctr = iter->second;
-	    swap_ctr(ctr, get_ctr);
-	    delete get_ctr;
-	  }
-	}
+      const YAML::Node& object = node["object"];
+      const YAML::Node& bucket = node["bucket"];
+
+      if ( object.size() ) {
+	const YAML::Node& get = object["get"];
+	obj_get_ctr = parse_limit(get);
+	const YAML::Node& put = object["put"];
+	obj_put_ctr = parse_limit(put);
+	const YAML::Node& delete_obj = object["delete"];
+	obj_del_ctr = parse_limit(delete_obj);
+      }
+
+      if ( bucket.size() ) {
+	const YAML::Node& create = bucket["create"];
+	create_ctr = parse_limit(create);
+	const YAML::Node& delete_bucket = bucket["delete"];
+	del_ctr = parse_limit(delete_bucket);
       }
     } catch (...) {
-      dout(0) << "Error parsing GET limit for user: " << user << dendl;
+      dout(0) << "Error parsing limits, using defaults, user: " << user << dendl;
+      continue;
     }
 
-    api_counter_t *put_ctr;
-    try {
-      const YAML::Node& put = node["put"];
-      if ( (put_ctr = parse_limit(put)) == NULL ) {
-	throw;
-      } else {
-	if ( init ) {
-	  (*rgw_put_ctrs)[user] = put_ctr;
-	} else {
-	  api_ctr_it iter = rgw_put_ctrs->find(user);
-	  if ( iter != rgw_put_ctrs->end() ) {
-	    api_counter_t *ctr = iter->second;
-	    swap_ctr(ctr, put_ctr);
-	    delete put_ctr;
-	  }
-	}
-      }
-    } catch (...) {
-      dout(0) << "Error parsing PUT limit for user: " << user << dendl;
-    }
-
-    if ( get_ctr ) {
-      dout(0) << "User: " << user \
-	      << "\tGET: " << get_ctr->limit.read() \
-	      << "/" << get_period_str(get_ctr->period) << dendl;
-    }
-    if ( put_ctr ) {
-      dout(0) << "User: " << user \
-	      << "\tPUT: " << put_ctr->limit.read() \
-	      << "/" << get_period_str(put_ctr->period) << dendl;
-    }
+    if ( obj_get_ctr ) (*obj_get_ctr_map)[user] = obj_get_ctr;
+    if ( obj_put_ctr ) (*obj_put_ctr_map)[user] = obj_put_ctr;
+    if ( obj_del_ctr ) (*obj_del_ctr_map)[user] = obj_del_ctr;
+    if ( create_ctr )  (*bucket_create_ctrs)[user] = create_ctr;
+    if ( del_ctr )     (*bucket_delete_ctrs)[user] = del_ctr;
   }
 
-  dout(0) << "*** Final GET rate limit config ***" << dendl;
-  dump_limit_config(rgw_get_ctrs);
-  dout(0) << "*** Final PUT rate limit config ***" << dendl;
-  dump_limit_config(rgw_put_ctrs);
+  dout(0) << "*** Final object GET rate limit config ***" << dendl;
+  dump_limit_config(obj_get_ctr_map);
+  dout(0) << "*** Final object PUT rate limit config ***" << dendl;
+  dump_limit_config(obj_put_ctr_map);
+  dout(0) << "*** Final object DELETE rate limit config ***" << dendl;
+  dump_limit_config(obj_del_ctr_map);
+  dout(0) << "*** Final bucket CREATE rate limit config ***" << dendl;
+  dump_limit_config(bucket_create_ctrs);
+  dout(0) << "*** Final bucket DELETE rate limit config ***" << dendl;
+  dump_limit_config(bucket_delete_ctrs);
+
+  update_default_limits();
 
   return 0;
 }
@@ -244,8 +272,11 @@ class C_RateCtrSecTimeout : public Context {
 public:
   C_RateCtrSecTimeout() {}
   void finish(int r) {
-    reset_ctrs(rgw_get_ctrs, SECOND);
-    reset_ctrs(rgw_put_ctrs, SECOND);
+    reset_ctrs(obj_get_ctr_map, SECOND);
+    reset_ctrs(obj_put_ctr_map, SECOND);
+    reset_ctrs(obj_del_ctr_map, SECOND);
+    reset_ctrs(bucket_create_ctrs, SECOND);
+    reset_ctrs(bucket_delete_ctrs, SECOND);
     rate_ctr_timer_sec->add_event_after(ONE_SEC, new C_RateCtrSecTimeout);
   }
 };
@@ -254,8 +285,11 @@ class C_RateCtrMinTimeout : public Context {
 public:
   C_RateCtrMinTimeout() {}
   void finish(int r) {
-    reset_ctrs(rgw_get_ctrs, MINUTE);
-    reset_ctrs(rgw_put_ctrs, MINUTE);
+    reset_ctrs(obj_get_ctr_map, MINUTE);
+    reset_ctrs(obj_put_ctr_map, MINUTE);
+    reset_ctrs(obj_del_ctr_map, MINUTE);
+    reset_ctrs(bucket_create_ctrs, MINUTE);
+    reset_ctrs(bucket_delete_ctrs, MINUTE);
     rate_ctr_timer_min->add_event_after(ONE_MIN, new C_RateCtrMinTimeout);
   }
 };
@@ -264,8 +298,11 @@ class C_RateCtrHourTimeout : public Context {
 public:
   C_RateCtrHourTimeout() {}
   void finish(int r) {
-    reset_ctrs(rgw_get_ctrs, HOUR);
-    reset_ctrs(rgw_put_ctrs, HOUR);
+    reset_ctrs(obj_get_ctr_map, HOUR);
+    reset_ctrs(obj_put_ctr_map, HOUR);
+    reset_ctrs(obj_del_ctr_map, HOUR);
+    reset_ctrs(bucket_create_ctrs, HOUR);
+    reset_ctrs(bucket_delete_ctrs, HOUR);
     rate_ctr_timer_hour->add_event_after(ONE_HOUR, new C_RateCtrHourTimeout);
   }
 };
@@ -297,7 +334,7 @@ static void setup_timers()
 
 // API calls 'perf' counters
 // Per-account counters for accept + reject GET / PUT call
-// Counter names: rgw_api_{accept,reject}_{get,put}_<user>
+// Counter names: rgw_api_{accept,reject}_{obj,bucket}_{get,put,del}_<user>
 #define RGW_API_CTR_IDX   (17000)
 #define RGW_API_ACCEPT_CTR_NAME_PREFIX string("rgw_api_accept_")
 #define RGW_API_REJECT_CTR_NAME_PREFIX string("rgw_api_reject_")
@@ -324,78 +361,126 @@ static void add_api_reject_ctr(int ctr_idx, string ctr_name)
   add_api_ctr(ctr_idx, ctr_name);
 }
 
+static int init_ctr_set(RGW_api_ctr_t *ctr_map, const string ctr_prefix, int ctr_idx)
+{
+  for ( api_ctr_it iter = ctr_map->begin();
+	iter != ctr_map->end();
+	++iter ) {
+    string user = iter->first;
+    api_counter_t *ctr = iter->second;
+    add_api_accept_ctr(ctr_idx, ctr_prefix + user);
+    ctr->accept_idx = ctr_idx;
+    ctr_idx++;
+    add_api_reject_ctr(ctr_idx, ctr_prefix + user);
+    ctr->reject_idx = ctr_idx;
+    ctr_idx++;
+  }
+  return (ctr_idx);
+}
+
 static void rgw_init_api_ctrs(CephContext *cct)
 {
-  int num_rgw_api_ctrs = (rgw_get_ctrs->size() + rgw_put_ctrs->size()) * 2;
+  int num_rgw_api_ctrs = (obj_get_ctr_map->size() + obj_put_ctr_map->size() + obj_del_ctr_map->size() + \
+			  bucket_create_ctrs->size() + bucket_delete_ctrs->size()) * 2;
 
   // PerfCountersBuilder does a ()-style bounds check, hence the +1's
   rgw_api_ctr_pcb = new PerfCountersBuilder(cct, "rgw_api_counters",
 	RGW_API_CTR_IDX, RGW_API_CTR_IDX + num_rgw_api_ctrs + 1);
   int next_ctr_idx = RGW_API_CTR_IDX + 1;
 
-  for ( api_ctr_it iter = rgw_get_ctrs->begin();
-	iter != rgw_get_ctrs->end();
-	++iter ) {
-    string user = iter->first;
-    api_counter_t *ctr = iter->second;
-    dout(20) << "Adding GET: " << user << " @ " << next_ctr_idx << dendl;
-    add_api_accept_ctr(next_ctr_idx, string("get_") + user);
-    ctr->accept_idx = next_ctr_idx;
-    next_ctr_idx++;
-    add_api_reject_ctr(next_ctr_idx, string("get_") + user);
-    ctr->reject_idx = next_ctr_idx;
-    next_ctr_idx++;
-  }
-  for ( api_ctr_cit iter = rgw_put_ctrs->begin();
-	iter != rgw_put_ctrs->end();
-	++iter ) {
-    string user = iter->first;
-    api_counter_t *ctr = iter->second;
-    dout(20) << "Adding PUT: " << user << " @ " << next_ctr_idx << dendl;
-    add_api_accept_ctr(next_ctr_idx, string("put_") + user);
-    ctr->accept_idx = next_ctr_idx;
-    next_ctr_idx++;
-    add_api_reject_ctr(next_ctr_idx, string("put_") + user);
-    ctr->reject_idx = next_ctr_idx;
-    next_ctr_idx++;
-  }
+  next_ctr_idx = init_ctr_set(obj_get_ctr_map, string("obj_get_"), next_ctr_idx);
+  next_ctr_idx = init_ctr_set(obj_put_ctr_map, string("obj_put_"), next_ctr_idx);
+  next_ctr_idx = init_ctr_set(obj_del_ctr_map, string("obj_del_"), next_ctr_idx);
+  next_ctr_idx = init_ctr_set(bucket_create_ctrs, string("bucket_create_"), next_ctr_idx);
+  next_ctr_idx = init_ctr_set(bucket_delete_ctrs, string("bucket_delete_"), next_ctr_idx);
 
   rgw_api_ctrs = rgw_api_ctr_pcb->create_perf_counters();
   cct->get_perfcounters_collection()->add(rgw_api_ctrs);
 }
 
+static api_counter_t *add_default_rate_limit(RGW_api_ctr_t *ctr_map,
+					     api_counter_t *default_ctr,
+					     string user)
+{
+  api_counter_t *ctr = new api_counter_t();
+  init_api_limit(ctr, default_ctr->limit.read(), default_ctr->period);
+
+  default_limit_lock->Lock();
+  api_ctr_cit iter;
+  if ( (iter = ctr_map->find(user)) != ctr_map->end() ) {
+    // ... in case someone else added it to the map
+    delete ctr;
+    ctr = iter->second;
+  } else {
+    dout(0) << user << " : adding default limit = " << ctr->limit.read() << dendl;
+    (*ctr_map)[user] = ctr;
+  }
+  default_limit_lock->Unlock();
+  return ctr;
+}
 
 // Actual rate limit / api count check
-static bool rgw_op_rate_limit_ok(RGW_api_ctr_t *ctrs, string user)
+
+static bool rgw_op_rate_limit_ok(RGW_api_ctr_t *ctr_map,
+				 api_counter_t *default_ctr,
+				 string user)
 {
-  if ( !ctrs ) {
+  if ( !ctr_map ) {
     return true;
   }
+
   api_ctr_cit iter;
-  if ( (iter = ctrs->find(user)) != ctrs->end() ) {
-    api_counter_t *ctr = iter->second;
-    ctr->recvd.inc();
-    dout(20) << user << " : recvd = " << ctr->recvd.read() \
-	     << ", limit = " << ctr->limit.read() << dendl;
-    if ( ctr->recvd.read() > ctr->limit.read() ) {
-      rgw_api_ctrs->inc(ctr->reject_idx);
-      return false;
-    }
-    rgw_api_ctrs->inc(ctr->accept_idx);
+  api_counter_t *ctr;
+  if ( (iter = ctr_map->find(user)) != ctr_map->end() ) {
+    ctr = iter->second;
+  } else {
+    ctr = add_default_rate_limit(ctr_map, default_ctr, user);
   }
+
+  ctr->recvd.inc();
+  dout(20) << user << " : recvd = " << ctr->recvd.read() \
+	   << ", limit = " << ctr->limit.read() << dendl;
+  if ( ctr->recvd.read() > ctr->limit.read() ) {
+    if ( ctr->reject_idx != -1 ) rgw_api_ctrs->inc(ctr->reject_idx);
+    return false;
+  }
+  if ( ctr->reject_idx != -1 ) rgw_api_ctrs->inc(ctr->accept_idx);
   return true;
 }
 
 bool rgw_rate_limit_ok(string& user, RGWOp *op)
 {
-  RGW_api_ctr_t *ctrs = NULL;
-  if ( op->get_type() == RGW_OP_GET_OBJ ) {
-    ctrs = rgw_get_ctrs;
+  RGW_api_ctr_t *ctr_map = NULL;
+  api_counter_t *default_ctr = NULL;
+
+  RGWOpType op_type = op->get_type();
+  if ( op_type == RGW_OP_GET_OBJ ) {
+    ctr_map = obj_get_ctr_map;
+    default_ctr = &default_obj_get;
   }
-  if ( op->get_type() == RGW_OP_PUT_OBJ ) {
-    ctrs = rgw_put_ctrs;
+  if ( op_type == RGW_OP_PUT_OBJ ) {
+    ctr_map = obj_put_ctr_map;
+    default_ctr = &default_obj_put;
   }
-  return (ctrs ? rgw_op_rate_limit_ok(ctrs, user) : true);
+  if ( op_type == RGW_OP_DELETE_OBJ ) {
+    ctr_map = obj_del_ctr_map;
+    default_ctr = &default_obj_del;
+  }
+  if ( op_type == RGW_OP_DELETE_MULTI_OBJ ) {
+    // XXX: exhaust all current delete tokens ?
+    ctr_map = obj_del_ctr_map;
+    default_ctr = &default_obj_del;
+  }
+  if ( op_type == RGW_OP_CREATE_BUCKET ) {
+    ctr_map = bucket_create_ctrs;
+    default_ctr = &default_bucket_create;
+  }
+  if ( op_type == RGW_OP_DELETE_BUCKET ) {
+    ctr_map = bucket_delete_ctrs;
+    default_ctr = &default_bucket_delete;
+  }
+
+  return (ctr_map ? rgw_op_rate_limit_ok(ctr_map, default_ctr, user) : true);
 }
 
 
@@ -429,7 +514,7 @@ static void watch_config_file()
 
     if ( event.mask & IN_MODIFY ) {
       dout(0) << "inotify: config file modified" << dendl;
-      load_limit_config_file(false);
+      // load_limit_config_file();
     }
 
     if ( event.mask & IN_IGNORED ) {
@@ -453,12 +538,28 @@ public:
 
 
 // Setup maps, timers, file-watch
+
+static void setup_default_limits()
+{
+  init_api_limit(&default_obj_get, 1, MINUTE);
+  init_api_limit(&default_obj_put, 1, MINUTE);
+  init_api_limit(&default_obj_del, 1, HOUR);
+  init_api_limit(&default_bucket_create, 1, HOUR);
+  init_api_limit(&default_bucket_delete, 1, HOUR);
+}
+
 int rgw_rate_limit_init(CephContext *cct)
 {
-  rgw_put_ctrs = new RGW_api_ctr_t;
-  rgw_get_ctrs = new RGW_api_ctr_t;
+  default_limit_lock = new Mutex("default_limit_lock");
+  setup_default_limits();
 
-  if ( load_limit_config_file(true) < 0 ) {
+  obj_put_ctr_map = new RGW_api_ctr_t;
+  obj_get_ctr_map = new RGW_api_ctr_t;
+  obj_del_ctr_map = new RGW_api_ctr_t;
+  bucket_create_ctrs = new RGW_api_ctr_t;
+  bucket_delete_ctrs = new RGW_api_ctr_t;
+
+  if ( load_limit_config_file() < 0 ) {
     return -1;
   }
 

--- a/src/rgw/rgw_rate_limit.cc
+++ b/src/rgw/rgw_rate_limit.cc
@@ -141,20 +141,20 @@ static void update_default_limits()
   update_one_default_limit(&default_bucket_delete, bucket_delete_ctrs);
 }
 
-static api_counter_t *parse_limit(const YAML::Node& limit_data)
+static api_counter_t *parse_limit(const YAML::Node *limit_data)
 {
   api_counter_t *api_ctr = new api_counter_t();
   try {
-    if ( !limit_data.size() ) {
+    if ( !limit_data || !(limit_data->size()) ) {
       delete api_ctr;
       return NULL;
     }
 
     unsigned long long limit;
-    limit_data["limit"] >> limit;
+    (*limit_data)["limit"] >> limit;
     api_ctr->limit.set(limit);
     string period_str;
-    limit_data["period"] >> period_str;
+    (*limit_data)["period"] >> period_str;
     if ( (api_ctr->period = parse_period_str(period_str)) == UNDEF ) {
       delete api_ctr;
       return NULL;
@@ -201,22 +201,22 @@ static int load_limit_config_file()
     obj_get_ctr = obj_put_ctr = obj_del_ctr = NULL;
     create_ctr = del_ctr = NULL;
     try {
-      const YAML::Node& object = node["object"];
-      const YAML::Node& bucket = node["bucket"];
+      const YAML::Node *object = node.FindValue("object");
+      const YAML::Node *bucket = node.FindValue("bucket");
 
-      if ( object.size() ) {
-	const YAML::Node& get = object["get"];
+      if ( object && object->size() ) {
+	const YAML::Node *get = object->FindValue("get");
 	obj_get_ctr = parse_limit(get);
-	const YAML::Node& put = object["put"];
+	const YAML::Node *put = object->FindValue("put");
 	obj_put_ctr = parse_limit(put);
-	const YAML::Node& delete_obj = object["delete"];
+	const YAML::Node *delete_obj = object->FindValue("delete");
 	obj_del_ctr = parse_limit(delete_obj);
       }
 
-      if ( bucket.size() ) {
-	const YAML::Node& create = bucket["create"];
+      if ( bucket && bucket->size() ) {
+	const YAML::Node *create = bucket->FindValue("create");
 	create_ctr = parse_limit(create);
-	const YAML::Node& delete_bucket = bucket["delete"];
+	const YAML::Node *delete_bucket = bucket->FindValue("delete");
 	del_ctr = parse_limit(delete_bucket);
       }
     } catch (...) {


### PR DESCRIPTION
* support for default user limits, can be defined via config file
* missing op limit will be auto-created, from defaults, on first call