### PR TITLE
https://jira.fkinternal.com/browse/D42ONCALL-91

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+ceph (0.94.2-1~bpo70+1.fk8.1) stable; urgency=low
+
+  * Flipkart release
+    - Human-readble 'rados df' output
+    - Multi-threaded cache pool flush/evict
+
+ -- FK D42 team <d42-maintainers@flipkart.com>  Wed, 16 Aug 2017 15:08:42 +0530
+
 ceph (0.94.2-1~bpo70+1.fk8) stable; urgency=low
 
   * Flipkart release


### PR DESCRIPTION
Cache pool object flush & evict, with threads -- "simple" version
Invoke as: '# rados -p <pool name> fast-flush /file/with/object/names <thread count>'
* Spawns upto 100 threads to process specified file in equal-sized chunks
* Object name spanning chunk boundary *not* processed, so will report some errors
* This commit has *NOT* been tested extensively